### PR TITLE
makes fields editable, fix large amount of requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Versions
 
+## Unreleased
+
+- Fixes large amount of google requests when typing an address
+- Allows to set splitted address parts fields editable or disabled
+
 ## 3.0.1 - 06-30-2021
 
 - Fixes address parts inputs not auto filled

--- a/index.js
+++ b/index.js
@@ -12,6 +12,23 @@ module.exports = {
   },
 
   construct (self, options) {
+    const superLoad = self.load;
+    self.load = function(req, widgets, callback) {
+      return superLoad(req, widgets, function(err) {
+        if (err) {
+          return callback(err);
+        }
+
+        self.addGoogleApiKey(req);
+
+        return callback(null);
+      });
+    };
+
+    self.addGoogleApiKey = function (req) {
+      req.data.googleApiKey = options.googleApiKey;
+    };
+
     self.sanitizeFormField = function (req, form, widget, input, output) {
       const parts = Object.keys(widget.addressParts);
       if (widget.splitAddress && parts && parts.length) {

--- a/index.js
+++ b/index.js
@@ -12,11 +12,6 @@ module.exports = {
   },
 
   construct (self, options) {
-    self.on('apostrophe-pages:beforeSend', 'addGoogleApiKey');
-    self.addGoogleApiKey = function (req) {
-      req.data.googleApiKey = options.googleApiKey;
-    };
-
     self.sanitizeFormField = function (req, form, widget, input, output) {
       const parts = Object.keys(widget.addressParts);
       if (widget.splitAddress && parts && parts.length) {

--- a/lib/addressParts.js
+++ b/lib/addressParts.js
@@ -2,41 +2,50 @@ module.exports = {
   street_number: {
     label: 'Street Number Label',
     splitLabel: 'Split Street Number',
+    disabledLabel: 'Read Only Street Number Input',
     def: true
   },
   route: {
     label: 'Route Label',
     splitLabel: 'Split Route',
+    disabledLabel: 'Read Only Route Input',
     def: true
   },
   locality: {
     label: 'City Label',
     splitLabel: 'Split City',
+    disabledLabel: 'Read Only City Input',
     def: true
   },
   sublocality_level_1: {
     label: 'City Label (for NYC area)',
     splitLabel: 'Split City (for NYC area)',
+    disabledLabel: 'Read Only City Input (for NYC area)',
     def: false
   },
   administrative_area_level_1: {
     label: 'State Label',
     splitLabel: 'Split State',
+    disabledLabel: 'Read Only State Input',
     def: true
   },
   postal_code: {
     label: 'Postal Code Label',
     splitLabel: 'Split Postal Code',
+    disabledLabel: 'Read Only Postal Code Input',
     def: true
   },
   postal_town: {
     label: 'Postal Code Label (for UK and Sweden)',
     splitLabel: 'Split Postal Code (for UK and Sweden)',
+    disabledLabel: 'Read Only Postal Code Input (for UK and Sweden)',
+
     def: false
   },
   country: {
     label: 'Country Label',
     splitLabel: 'Split Country',
+    disabledLabel: 'Read Only Country Input',
     def: true
   }
 };

--- a/lib/migrations.js
+++ b/lib/migrations.js
@@ -14,7 +14,8 @@ module.exports = (self, parts) => {
             ...acc,
             [part]: {
               label: part,
-              splitted: item.addressParts.includes(part)
+              splitted: item.addressParts.includes(part),
+              disabled: true
             }
           };
         }, {});

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -139,7 +139,7 @@ module.exports = (options, addressParts) => {
       type: 'object',
       help: 'Optional: choose fields to split address to',
       schema: Object.entries(addressParts).map(([ key, {
-        label, splitLabel, def
+        label, splitLabel, disabledLabel, def
       } ]) => {
         return {
           name: key,
@@ -155,6 +155,12 @@ module.exports = (options, addressParts) => {
               name: 'splitted',
               type: 'boolean',
               def
+            },
+            {
+              label: disabledLabel,
+              name: 'disabled',
+              type: 'boolean',
+              def: true
             }
           ]
         };

--- a/public/js/lean.js
+++ b/public/js/lean.js
@@ -4,23 +4,26 @@ apos.utils.widgetPlayers['apostrophe-forms-google-address-field'] = function(el,
     // Editing the form in the piece modal, it is not active for submissions
     return;
   }
-
   var googleApiKey = el.querySelector('[data-apos-forms-google-api-key]').dataset.aposFormsGoogleApiKey;
+
   if (!googleApiKey) {
     // eslint-disable-next-line no-console
     console.error('apostrophe-forms-google-address-field-widgets error: missing Google API key');
+    return;
   }
 
   var scriptSrc = 'https://maps.googleapis.com/maps/api/js?key=' + googleApiKey + '&libraries=places';
   var alreadyLoaded = document.querySelector('script[src="' + scriptSrc + '"]');
+
   if (!alreadyLoaded) {
     var googleScript = document.createElement('script');
     googleScript.setAttribute('src', scriptSrc);
+    googleScript.onload = googleScriptLoaded;
     document.head.appendChild(googleScript);
   }
 
-  var input = el.querySelector('input[name=' + widget.fieldName + ']');
-  input.addEventListener('input', function () {
+  function googleScriptLoaded () {
+    var input = el.querySelector('input[name=' + widget.fieldName + ']');
     var google = window.google;
 
     var countries = widget.countries.map(function (countryObject) {
@@ -99,5 +102,5 @@ apos.utils.widgetPlayers['apostrophe-forms-google-address-field'] = function(el,
     formsWidget.addEventListener('apos-forms-validate', function(event) {
       event.input[inputName] = input.value;
     });
-  });
+  }
 };

--- a/public/js/lean.js
+++ b/public/js/lean.js
@@ -1,5 +1,6 @@
 apos.utils.widgetPlayers['apostrophe-forms-google-address-field'] = function(el, widget, options) {
   var formsWidget = apos.utils.closest(el, '[data-apos-widget="apostrophe-forms"]');
+
   if (!formsWidget) {
     // Editing the form in the piece modal, it is not active for submissions
     return;
@@ -15,15 +16,18 @@ apos.utils.widgetPlayers['apostrophe-forms-google-address-field'] = function(el,
   var scriptSrc = 'https://maps.googleapis.com/maps/api/js?key=' + googleApiKey + '&libraries=places';
   var alreadyLoaded = document.querySelector('script[src="' + scriptSrc + '"]');
 
+  var input = el.querySelector('input[name=' + widget.fieldName + ']');
+
   if (!alreadyLoaded) {
     var googleScript = document.createElement('script');
     googleScript.setAttribute('src', scriptSrc);
     googleScript.onload = googleScriptLoaded;
     document.head.appendChild(googleScript);
+  } else {
+    googleScriptLoaded();
   }
 
   function googleScriptLoaded () {
-    var input = el.querySelector('input[name=' + widget.fieldName + ']');
     var google = window.google;
 
     var countries = widget.countries.map(function (countryObject) {

--- a/views/widget.html
+++ b/views/widget.html
@@ -14,7 +14,7 @@
   type="string"
   id="{{ id }}" name="{{ widget.fieldName }}"
   placeholder="{{ widget.placeholder }}"
-  data-apos-forms-google-api-key="{{ data.googleApiKey }}"
+  data-apos-forms-google-api-key="{{ data.manager.options.googleApiKey }}"
   {% if widget.required -%} required {%- endif -%}
 />
 

--- a/views/widget.html
+++ b/views/widget.html
@@ -14,7 +14,7 @@
   type="string"
   id="{{ id }}" name="{{ widget.fieldName }}"
   placeholder="{{ widget.placeholder }}"
-  data-apos-forms-google-api-key="{{ data.manager.options.googleApiKey }}"
+  data-apos-forms-google-api-key="{{ data.googleApiKey }}"
   {% if widget.required -%} required {%- endif -%}
 />
 

--- a/views/widget.html
+++ b/views/widget.html
@@ -20,7 +20,6 @@
 
 {% if widget.splitAddress and widget.addressParts %}
   {% for addressPart, infos in widget.addressParts %}
-
     {% if infos.splitted %}
     {%- if widget.displaySplitAddress %} </br> {%- endif %}
       <label
@@ -42,7 +41,7 @@
         id="{{ widget.fieldName }}-{{ addressPart }}"
         name="{{ widget.fieldName }}-{{ addressPart }}"
         {%- if not widget.displaySplitAddress %} style="display: none;" {%- endif %}
-        disabled
+        {%- if infos.disabled %} disabled {%- endif %}
       />
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
[IN-26](https://apostrophecms.atlassian.net/browse/IN-26)
[IN-27](https://apostrophecms.atlassian.net/browse/IN-27)

## Purpose
Allow users to make address parts fields editable or disabled.
Fix the large amount of requests when typing in search input.
The problem was that we added a listener on the input but google already adds this listener so I removed it.
Last thing, I pass the google api key directly in the widget template through options rather that in a beforeSend, this way it's always accessible.

## How to test
Setup apostrophe forms and google forms in your project:
```javascript
    'apostrophe-forms': {
      formWidgets: {
        // other fields go here
        'apostrophe-forms-google-address-field': {}
      },
      optionLabelPosition: 'last'
    },
    'apostrophe-forms-widgets': {},
    'apostrophe-forms-google-address-field-widgets': {
      googleApiKey: 'You can ask me an Api key to test if needd'
    },

    'apostrophe-forms-text-field-widgets': {},
    'apostrophe-forms-textarea-field-widgets': {},

```

Then add it in one of your templates, like here:
```javascript

    {{ apos.area(data.page, 'body', {
    widgets: {
      'apostrophe-images': {
        size: 'full'
      },
      'apostrophe-forms': {}
    }
  }) }}
```

Lastly, create a form and a google form:
![image](https://user-images.githubusercontent.com/17548370/124486704-27fef380-ddae-11eb-8874-a05a01aeca6f.png)

Configure the google form with splitted addresses, you can now make them disabled or not.

Check in the network tab of your browser that you don't have too much request when searching for an address.

Thanks.