### PR TITLE
Pro 2708

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Versions
 
+## 4.1.0
+
+### Adds
+
+- Adds conditional field `isRequired` to splitted address parts. Adds a new data attribute on the input when required.
+
 ## 4.0.0 (2021-08-02)
 
 ### Breaks

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -160,7 +160,18 @@ module.exports = (options, addressParts) => {
               label: disabledLabel,
               name: 'disabled',
               type: 'boolean',
+              choices: [
+                {
+                  value: false,
+                  showFields: [ 'isRequired' ]
+                }
+              ],
               def: true
+            },
+            {
+              label: 'Is The Address Part Required',
+              name: 'isRequired',
+              type: 'boolean'
             }
           ]
         };

--- a/views/widget.html
+++ b/views/widget.html
@@ -47,4 +47,3 @@
     {% endif %}
   {% endfor %}
 {% endif %}
-

--- a/views/widget.html
+++ b/views/widget.html
@@ -42,7 +42,7 @@
         id="{{ widget.fieldName }}-{{ addressPart }}"
         name="{{ widget.fieldName }}-{{ addressPart }}"
         {% if not widget.displaySplitAddress -%} style="display: none;" {%- endif %}
-        {% if infos.disabled -%} disabled {%- endif %}
+        {% if infos.disabled -%} disabled {%- endif -%}
       />
     {% endif %}
   {% endfor %}

--- a/views/widget.html
+++ b/views/widget.html
@@ -21,7 +21,7 @@
 {% if widget.splitAddress and widget.addressParts %}
   {% for addressPart, infos in widget.addressParts %}
     {% if infos.splitted %}
-    {%- if widget.displaySplitAddress %} </br> {%- endif %}
+      {%- if widget.displaySplitAddress %} </br> {%- endif %}
       <label
         for="{{ addressPart }}"
         class="apos-forms-label {{ classPrefix + '__label' if classPrefix }}"
@@ -37,11 +37,12 @@
       </label>
       <input class="apos-forms-input {{ classPrefix + '__input' if classPrefix }}"
         data-apos-forms-input-{{ addressPart }}
+        {% if infos.isRequired -%} data-apos-is-required {%- endif %}
         type="string"
         id="{{ widget.fieldName }}-{{ addressPart }}"
         name="{{ widget.fieldName }}-{{ addressPart }}"
-        {%- if not widget.displaySplitAddress %} style="display: none;" {%- endif %}
-        {%- if infos.disabled %} disabled {%- endif %}
+        {% if not widget.displaySplitAddress -%} style="display: none;" {%- endif %}
+        {% if infos.disabled -%} disabled {%- endif %}
       />
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
[PRO-2708](https://linear.app/apostrophecms/issue/PRO-2708/[michelin]-google-forms-address-field-for-each-address-part-we-need-a)

## Summary

## What are the specific steps to test this change?

* Create form with google address fields widget. Or update one (no migration needed since we just add a field).
* make some splitted parts required.
* Check in frontend that required inputs have `data-apos-is-require` set.

## What kind of change does this PR introduce?

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
